### PR TITLE
Add valgrind support

### DIFF
--- a/.github/workflows/vade.yml
+++ b/.github/workflows/vade.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        run: sudo apt install --quiet -y make gcc nasm python3 bash
+        run: sudo apt install --quiet -y make gcc nasm python3 bash valgrind
       - name: Build and test
         run: bin/vade clean test

--- a/vade/Makefile
+++ b/vade/Makefile
@@ -28,7 +28,15 @@ VGOPTS:=--exit-on-first-error=yes --error-exitcode=128
 VGOPTS$(L)+=-q
 VGOPTS+=--leak-check=full
 
-RUNTEST:=$(VALGRIND) $(VGOPTS)
+ifeq (, $(shell which $(VALGRIND)))
+#$(error "NOT HAVE VALGRIND ($(VALGRIND))")
+RUN:=
+RUNTEST:=RUN
+else
+#$(error "HAVE VALGRIND ($(VALGRIND))")
+VGRUN:=$(VALGRIND) $(VGOPTS)
+RUNTEST:=VGRUN
+endif
 
 #SRCS=$(patsubst vade/src/test,,$(wildcard vade/src/*))
 SRCS=$(wildcard vade/src/*)
@@ -295,8 +303,8 @@ $(PKGS): vade/pkg/vade_dep.d
 .PHONY:$(RUN_TESTS)
 
 $(RUN_TESTS):
-	$(call BRIEF2,RUN,./$(@D)) $(RUNTEST) ./$(@D) $(TFLAGS) || exit $$?
-#	$(call BRIEF2,RUN,./$(@F)) ./$(@F)
+	$(call BRIEF2,$(RUNTEST),./$(@D)) ./$(@D) $(TFLAGS) || exit $$?
+#	$(call BRIEF2,RUNTEST,./$(@F)) ./$(@F)
 
 _check: $(RUN_TESTS)
 

--- a/vade/Makefile
+++ b/vade/Makefile
@@ -23,6 +23,12 @@ VADEMAKEINTERNAL:=make -f $(VADEROOT)/vade/Makefile_internal SILENTMAKE=$(SILENT
 AR:=ar
 NM:=nm
 NASM:=nasm
+VALGRIND:=valgrind
+VGOPTS:=--exit-on-first-error=yes --error-exitcode=128
+VGOPTS$(L)+=-q
+VGOPTS+=--leak-check=full
+
+RUNTEST:=$(VALGRIND) $(VGOPTS)
 
 #SRCS=$(patsubst vade/src/test,,$(wildcard vade/src/*))
 SRCS=$(wildcard vade/src/*)
@@ -289,7 +295,7 @@ $(PKGS): vade/pkg/vade_dep.d
 .PHONY:$(RUN_TESTS)
 
 $(RUN_TESTS):
-	$(call BRIEF2,RUN,./$(@D)) ./$(@D) $(TFLAGS) || exit $$?
+	$(call BRIEF2,RUN,./$(@D)) $(RUNTEST) ./$(@D) $(TFLAGS) || exit $$?
 #	$(call BRIEF2,RUN,./$(@F)) ./$(@F)
 
 _check: $(RUN_TESTS)


### PR DESCRIPTION
If `valgrind` is available, run it systematically on the package unit-tests.
Add an option to disable it at will (optout)