### PR TITLE
Support build/test set

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ It's suitable for simple (yet potentially interdependent) packages.
 The only caveat is your packages can't depend on external libraries (eg: libz, which would need manual LDLIBS+=-lz).
 For now these limitations are not addressed.
 
+A nice bonus is that unit-tests run automatically through `valgrind` if available.
+
 ## Install
 How to install vade for use:
 1) Clone vade repository somewhere (eg: ~/git/ns_vade)
@@ -63,29 +65,36 @@ Note that the APIs and messages are heavily inspired from GoogleTest.
 
 Here is the simplest way to create a minimalist test/vade project: (the `git init` convenience is to avoid setting VADEPATH)
 ```
-$ mkdir myproj
-$ cd myproj
+$ mkdir myroot
+$ cd myroot
 $ git init
-$ vade new a
+$ vade new myproj
 $ vade clean test
     RM  vade/pkg
     RM  vade/bin
-    CC  a.o
-    AR  a.a
-    AR  liba.a
-    CC  a_test.o
+    CC  myproj.o
+    AR  myproj.a
+    AR  libmyproj.a
+    CC  myproj_test.o
     CC  test.o
-    AR  a_test.a
-    AR  liba_test.a
-    CXX a_test.exe
-    RUN ./bin/a_test.exe
+    AR  myproj_test.a
+    AR  libmyproj_test.a
+    CXX myproj_test.exe
+    VGRUN       ./vade/bin/myproj_test.exe
 [==========] Running tests from test suite.
 [----------] Global test environment set-up.
-[ RUN      ] a_TestMock_
-[       OK ] a_TestMock_ (0 ms)
+[ RUN      ] myproj_TestMock_
+[       OK ] myproj_TestMock_ (0 ms)
 [----------] Global test environment tear-down
-[==========] 1 tests from test suite ran. (1 ms total)
+[==========] 1 tests from test suite ran. (15 ms total)
 [  PASSED  ] 1 tests.
+```
+
+Note that an arbitrary (set of) package to test can be specified:
+```
+$ vade clean test P+=pkg1 P+=pkg2
+<builds of pkg1 & pkg2 dependencies only>
+<tests of pkg1 & pkg2 only>
 ```
 
 Enjoy !

--- a/bin/vade
+++ b/bin/vade
@@ -153,7 +153,7 @@ ${VADENEW}) :
         echo -e "\t${VADENEW}\t\tCreate a new source package"
         echo -e "\t${VADEBUILD}\t\tBuild packages"
         echo -e "\t${VADECLEAN}\t\tRemove build files"
-        echo -e "\t${VADETEST}\t\tTest packages"
+        echo -e "\t${VADETEST}\t\tTest packages (default: all, or select a set by defining P)"
         echo -e ""
         if [ "x${VADECMD}" = "xhelp" ]; then
             exit 0
@@ -177,7 +177,7 @@ ${VADENEW}) :
         exit 0
         ;;
     ${VADETEST}) :
-        echo "Usage: ${VADE} ${VADESUBCMD} [build/test flags] [packages] [build/test flags & test binary flags]"
+        echo "Usage: ${VADE} ${VADESUBCMD} [build/test flags] [P+=<pkg1> [P+=<pkg2>] ...]"
         echo ""
         exit 0
         ;;
@@ -215,7 +215,7 @@ ${VADENEW}) :
         echo '#include "'"test/test.h"'"'
         echo ""
         echo "TEST_F(${PKG}, Mock) {"
-        echo '    TEST_LOG("Testing '"${PKG}"'..\n");'
+        echo '    TEST_LOG("Testing '"${PKG}"' Mock..\n");'
         echo "    EXPECT_EQ(42, ${PKG}_Mock());"
         echo "}"
     } > ${VADEPATH}/vade/src/${PKG}/${PKG}_test.c

--- a/vade/Makefile
+++ b/vade/Makefile
@@ -41,7 +41,11 @@ endif
 #SRCS=$(patsubst vade/src/test,,$(wildcard vade/src/*))
 SRCS=$(wildcard vade/src/*)
 DIRS=$(patsubst vade/src/%,%,$(SRCS))
+ifeq (,$(P))
 PKGS=$(patsubst %,vade/pkg/%,$(DIRS))
+else
+PKGS=$(patsubst %,vade/pkg/%,$(P))
+endif
 LIBS=$(patsubst vade/src/%,vade/pkg/lib%.a,$(SRCS))
 
 TESTS=$(patsubst %,vade/bin/%_test.exe,$(DIRS))


### PR DESCRIPTION
crude way to specify a set of packages to build/test:
```
$ vade clean test P+=pkg1 P+=pkg2
```