### PR TITLE
Basic code coverage support (gcov)

### DIFF
--- a/.github/workflows/vade.yml
+++ b/.github/workflows/vade.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Install dependencies
         run: sudo apt install --quiet -y make gcc python3 bash valgrind nasm
       - name: Build and test
-        run: bin/vade clean test
+        run: bin/vade clean cov

--- a/README.md
+++ b/README.md
@@ -194,6 +194,23 @@ $ vade clean test P=pkg1 P+=pkg2 [ P+=.. ]
 <tests of pkg1 & pkg2 only>
 ```
 
+Also, test coverage can be output as well:
+```
+$ vade cov
+    VGRUN       ./vade/bin/bar_test.exe
+[==========] Running tests from test suite.
+...
+... snip ...
+...
+[  PASSED  ] 5 tests.
+==================================
+Code coverage
+==================================
+vade/pkg/bar/bar.gcda: 100.00% of 3
+vade/pkg/bazcpp/bazcpp.gcda: 100.00% of 4
+vade/pkg/foo/foo.gcda: 100.00% of 2
+```
+
 Enjoy !
 
 [WorkflowBadge]: https://github.com/nsauzede/ns_vade/workflows/vade/badge.svg

--- a/bin/vade
+++ b/bin/vade
@@ -63,6 +63,7 @@ VADENEW="new"
 VADEBUILD="build"
 VADECLEAN="clean"
 VADETEST="test"
+VADECOV="cov"
 VADECMDS="$VADEHELP $VADECLEAN $VADEBUILD $VADETEST"
 
 VADEBIN=$0
@@ -158,6 +159,7 @@ ${VADENEW}) :
         echo -e "\t${VADEBUILD}\t\tBuild packages"
         echo -e "\t${VADECLEAN}\t\tRemove build files"
         echo -e "\t${VADETEST}\t\tTest packages (default: all, or select a set by defining P)"
+        echo -e "\t${VADECOV}\t\tTest packages and print test coverage (default: all, or select a set by defining P)"
         echo -e ""
         if [ "x${VADECMD}" = "xhelp" ]; then
             exit 0
@@ -177,6 +179,11 @@ ${VADENEW}) :
         ;;
     ${VADECLEAN}) :
         echo "Usage: ${VADE} ${VADESUBCMD} [-i] [-r] [-n] [-x] [build flags] [packages]"
+        echo ""
+        exit 0
+        ;;
+    ${VADETEST}) :
+        echo "Usage: ${VADE} ${VADESUBCMD} [build/test flags] [P+=<pkg1> [P+=<pkg2>] ...]"
         echo ""
         exit 0
         ;;
@@ -231,7 +238,10 @@ ${VADECLEAN}) :
     make ${SILENCEMAKE} -C ${VADEPATH} -f ${VADEROOT}/vade/Makefile clobber ${VADEARGS} VADE_VERSION="${VADE_VERSION}"
     ;;
 ${VADETEST}) :
-    make ${SILENCEMAKE} -C ${VADEPATH} -f ${VADEROOT}/vade/Makefile check ${VADEARGS} VADE_VERSION="${VADE_VERSION}"
+    make ${SILENCEMAKE} -C ${VADEPATH} -f ${VADEROOT}/vade/Makefile test ${VADEARGS} VADE_VERSION="${VADE_VERSION}"
+    ;;
+${VADECOV}) :
+    make ${SILENCEMAKE} -C ${VADEPATH} -f ${VADEROOT}/vade/Makefile cov ${VADEARGS} VADE_VERSION="${VADE_VERSION}"
     ;;
 *) :
     echo "${VADE}: unknown command \"${VADECMD}\""

--- a/vade/Makefile
+++ b/vade/Makefile
@@ -24,6 +24,7 @@ AR:=ar
 NM:=nm
 NASM:=nasm
 VALGRIND:=valgrind
+GCOV:=gcov
 VGOPTS:=--exit-on-first-error=yes --error-exitcode=128
 VGOPTS$(L)+=-q
 VGOPTS+=--leak-check=full
@@ -114,11 +115,26 @@ CXXFLAGS+=-Ivade/src
 CFLAGS+=-I$(VADEROOT)/vade/src
 CXXFLAGS+=-I$(VADEROOT)/vade/src
 
+COVFLAGS:=-fprofile-arcs -ftest-coverage
+COVLIBS:=-lgcov --coverage
+CFLAGS+=$(COVFLAGS)
+CXXFLAGS+=$(COVFLAGS)
+
 .PHONY:all check clean clobber
 
 all: vade/pkg vade/bin $(PKGS)
 build: all
 test: check
+cov: test
+	$(AT)echo "=================================="
+	$(AT)echo "Code coverage"
+	$(AT)echo "=================================="
+	$(AT)for d in $(DIRS); do \
+		for c in `ls vade/pkg/$$d/*.gcda 2> /dev/null | grep -v -e "_test.gcda" -e "/test.gcda"`; do \
+			echo -n "$$c: "; \
+			$(GCOV) -n $$c |grep "Lines executed:"|head -n 1|cut -f 2 -d":"; \
+		done; \
+	done
 
 vade/pkg vade/bin:
 	$(AT)mkdir -p $@
@@ -268,12 +284,12 @@ TEST_SYMS+=$(shell $(NM) vade/pkg/$(STEM)/*_test.o | grep \ T\ _Z[0-9]*$(STEM)_T
 vade/bin/%_test.exe: $(TESTLIB) | $(TESTLIB)
 #	$(AT)echo "%_test.exe: how to build $@ ? stem=$* STEM=$(STEM) F=$(@F) f=$(patsubst lib%.a,%,$(@F)) D=$(@D) prereq=$^"
 #	$(call BRIEF,CC) -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive -ldl -rdynamic $(CFLAGS)
-	$(call BRIEF,CXX) -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive -ldl -rdynamic
+	$(call BRIEF,CXX) -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive -ldl -rdynamic $(COVLIBS)
 #	$(call BRIEF,CC) -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive -ldl -rdynamic
 
 vade/bin/%.exe: $(LIB) | $(LIB)
 #	echo "DOING %.exe for STEM=$(STEM)"
-	$(call BRIEF,CXX) -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive
+	$(call BRIEF,CXX) -o $@ -Wl,--whole-archive $^ -Wl,--no-whole-archive $(COVLIBS)
 
 .PHONY:$(PKGS)
 


### PR DESCRIPTION
This adds a new `vade` command : `vade cov`, which builds C/C++ sources with gcov support,
run the tests and print a basic per-package test-coverage report.