### PR TITLE
Support packages spanning through subdirs

### DIFF
--- a/bin/deps.py
+++ b/bin/deps.py
@@ -17,12 +17,16 @@ def isheader(fil):
 def dep(line):
         print("%s" % line)
         ls=line.split(".o: ")
-#        print("ls=%s" % ls)
-        rule=ls[0].split("/")
-        if len(rule) < 4:
-                return
-        pkg=rule[2]
-        tgt=rule[3]
+        #print(f"# ls={ls}")
+        dirname=os.path.dirname(ls[0])
+        #print(f"# dirname={dirname}")
+        pkg=dirname.split('vade/pkg/')[1]
+        tgt=os.path.basename(ls[0])
+#        if len(rule) < 4:
+#                return
+#        pkg=rule[2]
+#        tgt=rule[3]
+        #print(f"# pkg={pkg} tgt={tgt}")
         if len(ls) < 2:
                 return
         deps=ls[1]
@@ -33,11 +37,13 @@ def dep(line):
         print("vade/pkg/%s/%s.a: vade/pkg/%s/%s.o" % (pkg, tgt, pkg, tgt), end="")
 #        print("vade/pkg/%s/%s.a:" % (pkg, tgt), end="")
         for dep in deps.split(" "):
-                dls = dep.split("/")
-                ddir = dls[-3]
-                dpkg = dls[-2]
-                dfil = dls[-1]
+                #print(f"# dep={dep} \\")
+                dirname=os.path.dirname(dep)
+                #print(f"# dirname={dirname} \\")
+                dpkg = dirname.split("vade/src/")[1]
+                dfil = os.path.basename(dep)
                 pfx = dfil.split('.')[0]
+                #print(f"# dpkg={dpkg} dfil={dfil} pfx={pfx} \\")
                 if dpkg != pkg:
                         continue
                 if not tgt.endswith("_test"):
@@ -52,15 +58,19 @@ def dep(line):
         ddeps=[]
         print("vade/pkg/%s/lib%s.a:" % (pkg, tgt), end="")
         for dep in deps.split(" "):
+                #print(f"# ZORG dep={dep} \\")
+                dirname=os.path.dirname(dep)
+                #print(f"# ZORG dirname={dirname} \\")
                 dls = dep.split("/")
                 ddir = dls[-3]
-                dpkg = dls[-2]
-                dfil = dls[-1]
+                dpkg = dirname.split("vade/src/")[1]
+                dfil = os.path.basename(dep)
                 pfx = dfil.split('.')[0]
+                #print(f"# ZIRG dpkg={dpkg} dfil={dfil} pfx={pfx}")
                 if not tgt.endswith("_test"):
                         if isheader(dfil):
                                 if dpkg!=pkg:
-                                        print(" vade/pkg/%s/%s.a" % (dpkg, dpkg), end="")
+                                        print(" vade/pkg/%s/%s.a" % (dpkg, pfx), end="")
                                         ddeps += [dpkg]
                         else:
                                 print(" vade/pkg/%s/%s.a" % (dpkg, pfx), end="")
@@ -69,8 +79,8 @@ def dep(line):
                                 if dep.endswith("vade/src/test/test.h"):
                                         print(" vade/pkg/%s/test.o" % pkg)
                                 else:
-                                        if dpkg==pfx:
-                                                print(" vade/pkg/%s/%s.a" % (dpkg, dpkg), end="")
+                                        if os.path.basename(dpkg)==pfx:
+                                                print(" vade/pkg/%s/%s.a" % (dpkg, pfx), end="")
                         else:
                                 print(" vade/pkg/%s/%s.a" % (dpkg, pfx), end="")
         if len(ddeps)>0:

--- a/bin/vade
+++ b/bin/vade
@@ -20,7 +20,7 @@ vadecalled=$_
 #echo "Testing if script is being sourced.."
 if [ $vadecalled == $0 ]; then
 
-VADE_VERSION="0.0.4"
+VADE_VERSION="0.0.5"
 
 VADEBUILD="build"
 VADECLEAN="clean"
@@ -98,6 +98,8 @@ ${VADENEW}) :
         exit 1
     fi
     PKG=${VADESUBCMD}
+    PKGNAME=${PKG////_}
+    PKGBASE=`basename ${PKG}`
     if [ "x${PKG}" == "xtest" ]; then
         echo "Package name 'test' is reserved"
         exit 1
@@ -167,34 +169,42 @@ esac
 
 test -d ${VADEPATH} || (echo "can't load package: package .: no buildable source files in ${VADEPATH}" ; exit 1)
 
+#echo "PKG=${PKG}"
+#echo "PKGNAME=${PKGNAME}"
+#echo "PKGBASE=${PKGBASE}"
+
 case ${VADECMD} in
 ${VADENEW}) :
+#    echo "MKDIR.."
     mkdir -p ${VADEPATH}/vade/src/${PKG}
+#    echo "ECHO .h.."
     {
-        echo "#ifndef ${PKG^^}_H__"
-        echo "#define ${PKG^^}_H__"
+        echo "#ifndef ${PKGNAME^^}_H__"
+        echo "#define ${PKGNAME^^}_H__"
         echo ""
-        echo "int ${PKG}_Mock();"
+        echo "int ${PKGNAME}_Mock();"
         echo ""
-        echo "#endif/*${PKG^^}_H__*/"
-    } > ${VADEPATH}/vade/src/${PKG}/${PKG}.h
+        echo "#endif/*${PKGNAME^^}_H__*/"
+    } > ${VADEPATH}/vade/src/${PKG}/${PKGBASE}.h
+#    echo "ECHO .c.."
     {
-        echo '#include "'"${PKG}.h"'"'
+        echo '#include "'"${PKGBASE}.h"'"'
         echo ""
-        echo "int ${PKG}_Mock() {"
+        echo "int ${PKGNAME}_Mock() {"
         echo "    return 42;"
         echo "}"
-    } > ${VADEPATH}/vade/src/${PKG}/${PKG}.c
+    } > ${VADEPATH}/vade/src/${PKG}/${PKGBASE}.c
+#    echo "ECHO _test.c.."
     {
-        echo '#include "'"${PKG}.h"'"'
+        echo '#include "'"${PKGBASE}.h"'"'
         echo ""
         echo '#include "'"test/test.h"'"'
         echo ""
-        echo "TEST_F(${PKG}, Mock) {"
-        echo '    TEST_LOG("Testing '"${PKG}"' Mock..\n");'
-        echo "    EXPECT_EQ(42, ${PKG}_Mock());"
+        echo "TEST_F(${PKGNAME}, Mock) {"
+        echo '    TEST_LOG("Testing '"${PKGNAME}"' Mock..\n");'
+        echo "    EXPECT_EQ(42, ${PKGNAME}_Mock());"
         echo "}"
-    } > ${VADEPATH}/vade/src/${PKG}/${PKG}_test.c
+    } > ${VADEPATH}/vade/src/${PKG}/${PKGBASE}_test.c
     ;;
 ${VADEBUILD}) :
     make ${SILENCEMAKE} -C ${VADEPATH} -f ${VADEMAKEFILE} all ${VADEARGS} VADE_VERSION="${VADE_VERSION}"


### PR DESCRIPTION
Support package hierarchy like: `cool/pkg/pkg.h`
In this case, the package name would be `cool/pkg`
This allows to avoid putting all packages "flat" in `vade/src/<all packages here>`